### PR TITLE
NOT FOR MERGING - workaround for multiple notification center delegate registrations

### DIFF
--- a/flutter_local_notifications/macos/Classes/FlutterLocalNotificationsPlugin.swift
+++ b/flutter_local_notifications/macos/Classes/FlutterLocalNotificationsPlugin.swift
@@ -86,6 +86,8 @@ public class FlutterLocalNotificationsPlugin: NSObject, FlutterPlugin, UNUserNot
     var launchingAppFromNotification = false
     let presentationOptionsUserDefaults = "flutter_local_notifications_presentation_options"
 
+    static var registered = false;
+
     // MARK: - FlutterPlugin initialization and registration
 
     init(fromChannel channel: FlutterMethodChannel) {
@@ -93,6 +95,13 @@ public class FlutterLocalNotificationsPlugin: NSObject, FlutterPlugin, UNUserNot
     }
 
     public static func register(with registrar: FlutterPluginRegistrar) {
+        if (registered) {
+            return;
+        }
+        registered = true;
+        // Above is a hacky workaround to prevent attempting to register (and replacing) the notification
+        // center delegate multiple times.
+
         let channel = FlutterMethodChannel(name: "dexterous.com/flutter/local_notifications", binaryMessenger: registrar.messenger)
         let instance = FlutterLocalNotificationsPlugin.init(fromChannel: channel)
         if #available(macOS 10.14, *) {


### PR DESCRIPTION
ℹ️ 

This PR just serves as to show the workaround, that is why this fork exists. See code and comments 👀 

If, in the future, we need to upgrade the version of `flutter_local_notifications` that we use, simply rebase this branch, and update the commit we target in superlist's pubspec!